### PR TITLE
Fix shell integration bugs and Apple Silicon paths

### DIFF
--- a/.exports
+++ b/.exports
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Make Visual Studio Code the default editor.
-export EDITOR="/usr/local/bin/code -w";
+export EDITOR="code -w";
 
 # Use standard ISO 8601 timestamp:
 # %F equivalent to %Y-%m-%d

--- a/.zshrc
+++ b/.zshrc
@@ -101,7 +101,7 @@ zstyle :prompt:pure:git:stash show yes
 # Enable iTerm2 shell integration.
 [[ -f "$HOME/.iterm2_shell_integration.zsh" ]] && builtin source "$HOME/.iterm2_shell_integration.zsh"
 
-# Enable VS Code shell intergration.
+# Enable VS Code shell integration.
 [[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --locate-shell-integration-path zsh)"
 
 # Enable 1Password CLI completions.

--- a/.zshrc
+++ b/.zshrc
@@ -96,7 +96,7 @@ zstyle :prompt:pure:path color 'cyan'
 zstyle :prompt:pure:git:stash show yes
 
 # Enable iTerm2 shell integration.
-[[ -f "$HOME/.item2_shell_integration.zsh" ]] && builtin source "$HOME/.item2_shell_integration.zsh"
+[[ -f "$HOME/.iterm2_shell_integration.zsh" ]] && builtin source "$HOME/.iterm2_shell_integration.zsh"
 
 # Enable VS Code shell intergration.
 [[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --locate-shell-integration-path zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -68,6 +68,9 @@ plugins=(
 # Enable agent forwarding (required for Docker for Mac)
 # zstyle :omz:plugins:ssh-agent agent-forwarding on
 
+# Add Docker CLI completions to `fpath` before Oh My Zsh runs `compinit`.
+[[ -d "$HOME/.docker/completions" ]] && fpath=($HOME/.docker/completions $fpath)
+
 # Load Oh My Zsh.
 builtin source $ZSH/oh-my-zsh.sh
 
@@ -100,13 +103,6 @@ zstyle :prompt:pure:git:stash show yes
 
 # Enable VS Code shell intergration.
 [[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --locate-shell-integration-path zsh)"
-
-# Enable Docker CLI completions.
-if [[ -d "$HOME/.docker/completions" ]]; then
-  fpath=($HOME/.docker/completions $fpath)
-  autoload -Uz compinit
-  compinit
-fi
 
 # Enable 1Password CLI completions.
 if command -v op >/dev/null 2>&1; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,6 @@ doIt() {
     --exclude ".DS_Store" --exclude ".editorconfig" \
     --exclude ".gitignore" --exclude "bootstrap.sh" \
     --exclude "README.md" --exclude "LICENSE.md" -avh --no-perms . ~
-  # . "$HOME/.zshrc"
 }
 
 if [ "$1" = "--force" ] || [ "$1" = "-f" ]; then

--- a/init/brew/install-brew-formulae.sh
+++ b/init/brew/install-brew-formulae.sh
@@ -27,7 +27,7 @@ brew bundle install --file="$SCRIPT_DIR/Brewfile"
 
 # Use GNU tools like sha256sum.
 echo "⚠️  Do not forget to add $(brew --prefix coreutils)/libexec/gnubin to \$PATH."
-ln -sf "$(brew --prefix coreutils)/bin/gsha256sum" /usr/local/bin/sha256sum
+ln -sf "$(brew --prefix coreutils)/bin/gsha256sum" "$(brew --prefix)/bin/sha256sum"
 
 # Switch to using Brew-installed Zsh as default shell.
 zsh_path="$(brew --prefix)/bin/zsh"

--- a/init/terminal/install-zsh.sh
+++ b/init/terminal/install-zsh.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Install oh-my-zsh.
-sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # Install plugins.
 git clone https://github.com/djui/alias-tips.git "${ZSH_CUSTOM1:-$ZSH/custom}/plugins/alias-tips"


### PR DESCRIPTION
Small, focused fixes found while reviewing the repo. Each concern is its own commit.

## Bugs
- **iTerm2 shell integration never loaded** — the guarded `source` pointed at `~/.item2_shell_integration.zsh` (missing the second `r`); corrected to `~/.iterm2_shell_integration.zsh`.
- **Dead Oh My Zsh installer host** — `raw.github.com` is deprecated; switched to `raw.githubusercontent.com`.

## Apple Silicon portability
- Stop hardcoding the Intel `/usr/local/bin` prefix:
  - `EDITOR` now relies on `$PATH` (`code -w`) instead of `/usr/local/bin/code`.
  - `sha256sum` symlink target is `$(brew --prefix)/bin` instead of `/usr/local/bin`.

## Cleanups
- Add Docker completions to `fpath` *before* Oh My Zsh runs `compinit`, avoiding a redundant second `compinit` on startup.
- Fix "intergration" → "integration" comment typo.
- Remove a dead commented-out reload line in `bootstrap.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)